### PR TITLE
#4 Support GPIO Device

### DIFF
--- a/devices/Linux/Makefile
+++ b/devices/Linux/Makefile
@@ -12,7 +12,7 @@ include $(POCO_BASE)/build/rules/global
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 
-objects = LinuxLED BundleActivator 
+objects = LinuxGPIO LinuxLED BundleActivator
 
 target         = io.macchina.linux
 target_version = 1

--- a/devices/Linux/src/BundleActivator.cpp
+++ b/devices/Linux/src/BundleActivator.cpp
@@ -19,9 +19,11 @@
 #include "Poco/OSP/PreferencesService.h"
 #include "Poco/RemotingNG/ORB.h"
 #include "IoT/Devices/LEDServerHelper.h"
+#include "IoT/Devices/IOServerHelper.h"
 #include "Poco/ClassLibrary.h"
 #include "Poco/Format.h"
 #include "Poco/NumberFormatter.h"
+#include "Poco/NumberParser.h"
 #include "Poco/SharedPtr.h"
 #include "Poco/File.h"
 #include "Poco/Path.h"
@@ -29,8 +31,10 @@
 #include "Poco/Format.h"
 #include "Poco/StringTokenizer.h"
 #include "LinuxLED.h"
+#include "LinuxGPIO.h"
 #include <vector>
 #include <set>
+#include <map>
 
 
 using Poco::OSP::BundleContext;
@@ -51,29 +55,29 @@ public:
 	BundleActivator()
 	{
 	}
-	
+
 	~BundleActivator()
 	{
 	}
-	
+
 	void createLED(const std::string& device)
 	{
 		typedef Poco::RemotingNG::ServerHelper<IoT::Devices::LED> ServerHelper;
-		
+
 		std::string oid(LinuxLED::SYMBOLIC_NAME);
 		oid += '#';
 		oid += Poco::Path(device).getFileName();
-		
+
 		Poco::SharedPtr<LinuxLED> pLED = new LinuxLED(device, _pTimer);
 		ServerHelper::RemoteObjectPtr pLEDRemoteObject = ServerHelper::createRemoteObject(pLED, oid);
-		
+
 		Properties props;
 		props.set("io.macchina.device", LinuxLED::SYMBOLIC_NAME);
-		
+
 		ServiceRef::Ptr pServiceRef = _pContext->registry().registerService(oid, pLEDRemoteObject, props);
 		_serviceRefs.push_back(pServiceRef);
 	}
-	
+
 	void createLEDs(const std::set<std::string>& deviceWhitelist)
 	{
 		Poco::File ledsDir("/sys/class/leds");
@@ -101,13 +105,48 @@ public:
 			}
 		}
 	}
-	
+
+	void createGPIO(const std::string& pin, const std::string& direction)
+	{
+		typedef Poco::RemotingNG::ServerHelper<IoT::Devices::IO> ServerHelper;
+
+		std::string oid(LinuxGPIO::SYMBOLIC_NAME);
+		oid += '#';
+		oid += pin;
+
+		const int pinIndex = Poco::NumberParser::parse(pin);
+		LinuxGPIO::Direction gpioDirection = LinuxGPIO::toDirection(direction);
+
+		Poco::SharedPtr<LinuxGPIO> pGPIO = new LinuxGPIO(pinIndex, gpioDirection);
+		ServerHelper::RemoteObjectPtr pGPIORemoteObject = ServerHelper::createRemoteObject(pGPIO, oid);
+
+		Properties props;
+		props.set("io.macchina.device", LinuxGPIO::SYMBOLIC_NAME);
+
+		ServiceRef::Ptr pServiceRef = _pContext->registry().registerService(oid, pGPIORemoteObject, props);
+		_serviceRefs.push_back(pServiceRef);
+	}
+
+	void createGPIOs(const std::map<std::string, std::string>& deviceWhitelist)
+	{
+		Poco::File gpioDir("/sys/class/gpio");
+		if (gpioDir.exists() && gpioDir.isDirectory())
+		{
+			std::map<std::string, std::string>::const_iterator it = deviceWhitelist.begin();
+			std::map<std::string, std::string>::const_iterator end = deviceWhitelist.end();
+			for (;it != end; ++it)
+			{
+				createGPIO(it->first, it->second);
+			}
+		}
+	}
+
 	void start(BundleContext::Ptr pContext)
 	{
 		_pTimer = new Poco::Util::Timer;
 		_pContext = pContext;
 		_pPrefs = ServiceFinder::find<PreferencesService>(pContext);
-		
+
 		try
 		{
 			if (_pPrefs->configuration()->getBool("linux.leds.enable", true))
@@ -117,13 +156,32 @@ public:
 				std::set<std::string> deviceWhitelist(tok.begin(), tok.end());
 				createLEDs(deviceWhitelist);
 			}
+
+			if (_pPrefs->configuration()->getBool("linux.gpio.enable", true))
+			{
+				std::map<std::string, std::string> gpioMap;
+				Poco::Util::AbstractConfiguration::Keys keys;
+				_pPrefs->configuration()->keys("gpio.pins", keys);
+
+				for (std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); ++it)
+				{
+					std::string baseKey = "gpio.pins.";
+					baseKey += *it;
+
+					std::string device = _pPrefs->configuration()->getString(baseKey + ".device", "");
+					std::string direction = _pPrefs->configuration()->getString(baseKey + ".direction", "out");
+					gpioMap[device] = direction;
+				}
+
+				createGPIOs(gpioMap);
+			}
 		}
 		catch (Poco::Exception& exc)
 		{
 			_pContext->logger().log(exc);
 		}
 	}
-		
+
 	void stop(BundleContext::Ptr pContext)
 	{
 		_pTimer->cancel(true);
@@ -138,7 +196,7 @@ public:
 		_pPrefs = 0;
 		_pContext = 0;
 	}
-	
+
 private:
 	Poco::SharedPtr<Poco::Util::Timer> _pTimer;
 	BundleContext::Ptr _pContext;

--- a/devices/Linux/src/LinuxGPIO.cpp
+++ b/devices/Linux/src/LinuxGPIO.cpp
@@ -1,0 +1,238 @@
+//
+// LinuxGPIO.cpp
+//
+// $Id$
+//
+// Copyright (c) 2009-2015, Applied Informatics Software Engineering GmbH.
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#include "LinuxGPIO.h"
+
+#include <unistd.h>
+#include <poll.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "Poco/NumberFormatter.h"
+#include "Poco/Format.h"
+#include "Poco/FileStream.h"
+#include "Poco/File.h"
+#include "Poco/Exception.h"
+
+
+namespace IoT {
+namespace Linux {
+
+
+const std::string LinuxGPIO::NAME("Linux GPIO");
+const std::string LinuxGPIO::TYPE("io.macchina.io");
+const std::string LinuxGPIO::SYMBOLIC_NAME("io.macchina.linux.gpio");
+const std::string LinuxGPIO::LOGGER_NAME("IO.GPIO");
+
+
+LinuxGPIO::LinuxGPIO(const int pin, LinuxGPIO::Direction direction):
+	_pin(pin),
+	_direction(direction),
+    _gpioPath("/sys/class/gpio"),
+    _eventActivity(this, &LinuxGPIO::watchInputPin),
+    _logger(Poco::Logger::get(LOGGER_NAME))
+{
+	addProperty("symbolicName", &LinuxGPIO::getSymbolicName);
+	addProperty("name", &LinuxGPIO::getName);
+	addProperty("type", &LinuxGPIO::getType);
+	addProperty("device", &LinuxGPIO::getDevice);
+	addProperty("direction", &LinuxGPIO::getDirection);
+	addProperty("state", &LinuxGPIO::getState, &LinuxGPIO::setState);
+
+    exportPin(_pin);
+    setDirection(_pin, _direction);
+    if ((direction == DIRECTION_IN) && canInterrupt())
+    {
+        _eventActivity.start();
+    }
+}
+
+LinuxGPIO::~LinuxGPIO()
+{
+    if (!_eventActivity.isStopped())
+    {
+        _eventActivity.stop();
+        _eventActivity.wait();
+    }
+    unexportPin(_pin);
+}
+
+Poco::Any LinuxGPIO::getName(const std::string&) const
+{
+	return NAME;
+}
+
+Poco::Any LinuxGPIO::getType(const std::string&) const
+{
+	return TYPE;
+}
+
+Poco::Any LinuxGPIO::getSymbolicName(const std::string&) const
+{
+	return SYMBOLIC_NAME;
+}
+
+Poco::Any LinuxGPIO::getDevice(const std::string&) const
+{
+	return Poco::NumberFormatter::format(_pin);
+}
+
+Poco::Any LinuxGPIO::getDirection(const std::string&) const
+{
+	return LinuxGPIO::toString(_direction);
+}
+
+Poco::Any LinuxGPIO::getState(const std::string&) const
+{
+	return state();
+}
+
+void LinuxGPIO::setState(const std::string&, const Poco::Any& value)
+{
+	set(Poco::AnyCast<bool>(value));
+}
+
+std::string LinuxGPIO::toString(LinuxGPIO::Direction direction)
+{
+	return (direction == LinuxGPIO::DIRECTION_OUT) ? "out" : "in";
+}
+
+LinuxGPIO::Direction LinuxGPIO::toDirection(const std::string& direction)
+{
+    if (direction == "in")
+    {
+        return LinuxGPIO::DIRECTION_IN;
+    }
+    else if (direction == "out")
+    {
+        return LinuxGPIO::DIRECTION_OUT;
+    }
+    else
+    {
+        throw Poco::InvalidArgumentException("Invalid direction type", direction);
+    }
+}
+
+template <typename T>
+void LinuxGPIO::writeHelper(const std::string& path, const T& value) const
+{
+    std::string file_path = pathHelper(path);
+    Poco::FastMutex::ScopedLock lock(_mutex);
+    Poco::FileOutputStream ostr(file_path);
+    ostr << value << std::endl;
+}
+
+std::string LinuxGPIO::pathHelper(const std::string path) const
+{
+    return _gpioPath.toString() + path;
+}
+
+void LinuxGPIO::exportPin(int pin) const
+{
+    writeHelper("/export", pin);
+}
+
+void LinuxGPIO::unexportPin(int pin) const
+{
+    writeHelper("/unexport", pin);
+}
+
+void LinuxGPIO::registerEvent(int pin) const
+{
+    writeHelper(Poco::format("/gpio%d/edge", pin), "both");
+}
+
+void LinuxGPIO::unregisterEvent(int pin) const
+{
+    writeHelper(Poco::format("/gpio%d/edge", pin), "none");
+}
+
+void LinuxGPIO::setDirection(int pin, LinuxGPIO::Direction direction) const
+{
+    std::string strDirection = toString(direction);
+	_logger.debug(Poco::format("Set direction as '%s' on gpio %d", strDirection, _pin));
+    writeHelper(Poco::format("/gpio%d/direction", pin), strDirection);
+}
+
+void LinuxGPIO::set(bool state)
+{
+    _logger.debug(Poco::format("Set state %d on gpio %s", state, _pin));
+    writeHelper(Poco::format("/gpio%d/value", _pin), state);
+}
+
+bool LinuxGPIO::state() const
+{
+    std::string file_path = pathHelper(Poco::format("/gpio%d/value", _pin));
+    Poco::FastMutex::ScopedLock lock(_mutex);
+    Poco::FileInputStream istr(file_path);
+    bool level;
+    istr >> level;
+    _logger.debug(Poco::format("Received state %d on gpio %d", level, _pin));
+    return level;
+}
+
+bool LinuxGPIO::canInterrupt()
+{
+    Poco::File event_file(pathHelper(Poco::format("/gpio%d/edge", _pin)));
+    return event_file.exists();
+}
+
+void LinuxGPIO::watchInputPin()
+{
+    const std::string file_path = pathHelper(Poco::format("/gpio%d/value", _pin));
+    const int fd = ::open(file_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+    if (fd == -1)
+    {
+        throw Poco::IOException("file open error", strerror(errno));
+    }
+
+    struct pollfd pollfdset = {fd, POLLIN, 0};
+    const nfds_t nfds = 1;
+    const int timeout_ms = 100;
+    int last_level = INT_MAX;
+
+    registerEvent(_pin);
+
+	_logger.debug(Poco::format("Watching gpio %d", _pin));
+
+    while (!_eventActivity.isStopped())
+    {
+        int result = ::poll(&pollfdset, nfds, timeout_ms);
+
+        if (result < 0)
+        {
+            throw Poco::IOException("file poll error", strerror(errno));
+        }
+        else if (result == 0)
+        {
+            continue;
+        }
+        else if (pollfdset.revents & POLLIN)
+        {
+            const int level = state();
+            if (last_level != level)
+            {
+                _logger.debug(Poco::format("Registered state %d on gpio %d", level, _pin));
+                stateChanged.notify(this, level);
+                last_level = level;
+            }
+        }
+    }
+
+    unregisterEvent(_pin);
+    ::close(fd);
+}
+
+
+} } // namespace IoT::Linux

--- a/devices/Linux/src/LinuxGPIO.h
+++ b/devices/Linux/src/LinuxGPIO.h
@@ -1,0 +1,122 @@
+//
+// LinuxGPIO.h
+//
+// $Id$
+//
+// Copyright (c) 2015, Applied Informatics Software Engineering GmbH.
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+#ifndef IoT_Linux_LinuxGPIO_INCLUDED
+#define IoT_Linux_LinuxGPIO_INCLUDED
+
+
+#include "Poco/Path.h"
+#include "Poco/Activity.h"
+#include "Poco/Mutex.h"
+#include "Poco/Logger.h"
+#include "Poco/AutoPtr.h"
+#include "IoT/Devices/DeviceImpl.h"
+#include "IoT/Devices/IO.h"
+
+
+namespace IoT {
+namespace Linux {
+
+
+class LinuxGPIO: public IoT::Devices::DeviceImpl<IoT::Devices::IO, LinuxGPIO>
+	/// Default implementation for LinuxGPIO using the Macchina.io GPIO class.
+{
+public:
+	typedef Poco::AutoPtr<LinuxGPIO> Ptr;
+
+    enum Direction
+    {
+        DIRECTION_IN,   /// GPIO pin as input
+        DIRECTION_OUT   /// GPIO pin as output
+    };
+
+	LinuxGPIO(const int pin, Direction direction);
+		/// Creates the LinuxGPIO using the given device name.
+
+	~LinuxGPIO();
+		/// Destroys the LinuxGPIO.
+
+	// GPIO
+	bool state() const;
+    void set(bool state);
+
+	static const std::string NAME;
+	static const std::string TYPE;
+	static const std::string SYMBOLIC_NAME;
+
+    static std::string toString(Direction direction);
+        /// Convert direction enum to string for linux sys
+
+    static Direction toDirection(const std::string& direction);
+        /// Convert string friendly-name to Direction enum
+
+protected:
+	Poco::Any getName(const std::string&) const;
+	Poco::Any getType(const std::string&) const;
+	Poco::Any getSymbolicName(const std::string&) const;
+	Poco::Any getDevice(const std::string&) const;
+	Poco::Any getDirection(const std::string&) const;
+	Poco::Any getState(const std::string&) const;
+	void setState(const std::string&, const Poco::Any& value);
+
+    static const std::string LOGGER_NAME;
+        /// GPIO Logger name
+
+private:
+
+    int _pin;
+        /// GPIO pin index
+    Direction _direction;
+        /// GPIO direction
+    Poco::Path _gpioPath;
+        /// GPIO prefix path
+    Poco::Activity<LinuxGPIO> _eventActivity;
+        /// Watch GPIO pin
+    Poco::Logger& _logger;
+        /// GPIO event logger
+    mutable Poco::FastMutex _mutex;
+        /// Mutex for GPIO value file
+
+    void exportPin(int pin) const;
+        /// Export control of a GPIO to userspace
+
+    void unexportPin(int pin) const;
+        /// Will remove a GPIO node exported
+
+    void registerEvent(int pin) const;
+        /// Set the signal edge(s) that will make poll
+
+    void unregisterEvent(int pin) const;
+        /// Disable event trigger
+
+    void setDirection(int pin, Direction direction) const;
+        /// Set direction of a GPIO as input or output
+
+    template <typename T>
+    void writeHelper(const std::string& path, const T& value) const;
+        /// Help to write any value in a GPIO file
+
+    std::string pathHelper(const std::string path) const;
+        /// Help to solve GPIO file path
+
+    void watchInputPin();
+        /// Use pin interruption to set GPIO event
+
+    bool canInterrupt();
+        /// Check if is possible to trigger interruption
+};
+
+
+} } // namespace IoT::Linux
+
+
+#endif // IoT_Linux_LinuxGPIO_INCLUDED


### PR DESCRIPTION
Hi!

I have started to develop the issue #4. As you can see, the library for GPIO on Linux is implemented. I have some boards to test this feature, as RaspberryPi, BeableBone, OrangePi and CHIP, the library worked very well with all of them.

The module is in *devices*, including the base access for gpio. I have the suspicion to move GPIO, GPIO_POSIX and GPIO_WIN32 to *platform* and stay only GPIODevice and BundleActivator in *devices*. However, platform is very coupled with Poco, so I don't know if is a good idea.

As next step, would be nice to create the web interface to access the GPIO, as made for Linux LEDs.

I'll be waiting for your review, Regards.