### PR TITLE
fix : allow shared_debug build

### DIFF
--- a/devices/Devices/Makefile-Bundle
+++ b/devices/Devices/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Devices bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/devices/GNSS/Makefile
+++ b/devices/GNSS/Makefile
@@ -6,7 +6,11 @@
 
 include $(POCO_BASE)/build/rules/global
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/devices/GNSS/NMEA/include

--- a/devices/Legato/Makefile
+++ b/devices/Legato/Makefile
@@ -6,7 +6,11 @@
 
 include $(POCO_BASE)/build/rules/global
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/devices/GNSS/NMEA/include

--- a/devices/Linux/Makefile
+++ b/devices/Linux/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Linux Devices Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 

--- a/devices/SensorTag/Makefile
+++ b/devices/SensorTag/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io SensorTag Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/protocols/BtLE/include

--- a/devices/Serial/Makefile
+++ b/devices/Serial/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Serial bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 

--- a/devices/Simulation/Makefile
+++ b/devices/Simulation/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Simulation Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 

--- a/devices/Tf/Makefile
+++ b/devices/Tf/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Tinkerforge Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 

--- a/devices/XBeeSensor/Makefile
+++ b/devices/XBeeSensor/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io XBee Sensor Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/protocols/XBee/include

--- a/devices/XDK/Makefile
+++ b/devices/XDK/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io XDK Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/protocols/BtLE/include

--- a/platform/OSP/BundleAdmin/Makefile
+++ b/platform/OSP/BundleAdmin/Makefile
@@ -4,9 +4,13 @@
 # Makefile for BundleAdmin
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleAdmin BundleInstallHandler BundleListHandler \
 	BundleInfoHandler RequestHandler

--- a/platform/OSP/Core/Makefile
+++ b/platform/OSP/Core/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Core Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = CoreBundleActivator
 

--- a/platform/OSP/Crypto/Makefile
+++ b/platform/OSP/Crypto/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Crypto Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = CryptoBundleActivator
 

--- a/platform/OSP/Data/Makefile
+++ b/platform/OSP/Data/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Data Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = DataBundleActivator
 

--- a/platform/OSP/JS/Data/Makefile
+++ b/platform/OSP/JS/Data/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP JS Data
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = DataModule
 

--- a/platform/OSP/JS/Makefile-Bundle
+++ b/platform/OSP/JS/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for OSP JS Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = JSBundleActivator
 

--- a/platform/OSP/JS/Net/Makefile
+++ b/platform/OSP/JS/Net/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP JS Net
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = NetModule
 

--- a/platform/OSP/JS/Scheduler/Makefile
+++ b/platform/OSP/JS/Scheduler/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP JS Scheduler
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = SchedulerExtensionPoint BundleActivator
 

--- a/platform/OSP/JS/Web/Makefile
+++ b/platform/OSP/JS/Web/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP JS Web Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = JSServletExecutor JSServletExecutorCache \
 	JSServletFilter JSServerPageFilter \

--- a/platform/OSP/Net/Makefile
+++ b/platform/OSP/Net/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Net Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = NetBundleActivator
 

--- a/platform/OSP/NetSSL_OpenSSL/Makefile
+++ b/platform/OSP/NetSSL_OpenSSL/Makefile
@@ -4,9 +4,13 @@
 # Makefile for NetSSL Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = NetSSLBundleActivator
 

--- a/platform/OSP/RemotingNG/TCP/Makefile
+++ b/platform/OSP/RemotingNG/TCP/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP RemotingNG TCP bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/platform/OSP/SecureWebServer/Makefile
+++ b/platform/OSP/SecureWebServer/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Poco OSP SecureWebServer Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = SecureWebServerBundleActivator
 

--- a/platform/OSP/SimpleAuth/Makefile
+++ b/platform/OSP/SimpleAuth/Makefile
@@ -4,9 +4,13 @@
 # Makefile for OSP SimpleAuth
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = SimpleAuth
 

--- a/platform/OSP/Unit/TestRunner/Makefile
+++ b/platform/OSP/Unit/TestRunner/Makefile
@@ -4,9 +4,13 @@
 # Makefile for TestRunner
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = TestRunnerBundleActivator
 

--- a/platform/OSP/Unit/samples/TestBundle/Makefile
+++ b/platform/OSP/Unit/samples/TestBundle/Makefile
@@ -4,9 +4,13 @@
 # Makefile for TestBundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = TestBundleActivator BundleTest TestBundleSuite
 

--- a/platform/OSP/Web/Makefile-Bundle
+++ b/platform/OSP/Web/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for Poco OSPWeb Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebBundleActivator
 

--- a/platform/OSP/WebEvent/Makefile-Bundle
+++ b/platform/OSP/WebEvent/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for Poco OSP WebEvent Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebEventServiceImpl WebEventRequestHandler WebEventBundleActivator
 

--- a/platform/OSP/WebServer/Makefile
+++ b/platform/OSP/WebServer/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Poco OSP WebServer Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebServerBundleActivator
 

--- a/platform/OSP/samples/Extensible/Makefile
+++ b/platform/OSP/samples/Extensible/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Extensible
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = Extensible
 

--- a/platform/OSP/samples/Extension/Makefile
+++ b/platform/OSP/samples/Extension/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Extension
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = Extension
 

--- a/platform/OSP/samples/Greeter/Makefile
+++ b/platform/OSP/samples/Greeter/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Greeter
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = Greeter
 

--- a/platform/OSP/samples/GreetingService/Makefile
+++ b/platform/OSP/samples/GreetingService/Makefile
@@ -4,9 +4,13 @@
 # Makefile for GreetingService
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = GreetingService
 

--- a/platform/OSP/samples/Preferences/Makefile
+++ b/platform/OSP/samples/Preferences/Makefile
@@ -4,9 +4,13 @@
 # Makefile for Preferences
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = Preferences
 

--- a/platform/OSP/samples/ServiceListener/Makefile
+++ b/platform/OSP/samples/ServiceListener/Makefile
@@ -4,9 +4,13 @@
 # Makefile for ServiceListener
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = ServiceListener
 

--- a/platform/OSP/samples/WebEcho/Makefile
+++ b/platform/OSP/samples/WebEcho/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebEcho sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebEcho
 

--- a/platform/OSP/samples/WebEvent/Makefile
+++ b/platform/OSP/samples/WebEvent/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebEvent sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebEventBundleActivator
 

--- a/platform/OSP/samples/WebFilter/Makefile
+++ b/platform/OSP/samples/WebFilter/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebFilter sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebFilter
 

--- a/platform/OSP/samples/WebIndex/Makefile
+++ b/platform/OSP/samples/WebIndex/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebIndex sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebIndex
 

--- a/platform/OSP/samples/WebInfo/Makefile
+++ b/platform/OSP/samples/WebInfo/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebInfo sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebInfo
 

--- a/platform/OSP/samples/WebPage/Makefile
+++ b/platform/OSP/samples/WebPage/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebPage
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebPage
 

--- a/platform/OSP/samples/WebSession/Makefile
+++ b/platform/OSP/samples/WebSession/Makefile
@@ -4,9 +4,13 @@
 # Makefile for WebSession sample
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = WebSession
 

--- a/protocols/BtLE/BlueZ/Makefile
+++ b/protocols/BtLE/BlueZ/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Bluetooth LE bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/protocols/BtLE/include
 

--- a/protocols/BtLE/Makefile-Bundle
+++ b/protocols/BtLE/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Bluetooth LE bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/protocols/MQTT/Makefile-Bundle
+++ b/protocols/MQTT/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io MQTT bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/protocols/MQTT/Paho/include
 

--- a/protocols/Modbus/Makefile-Bundle
+++ b/protocols/Modbus/Makefile-Bundle
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -n$(OSNAME) -a$(OSARCH) -o../bundles Modbus.bndlspec

--- a/protocols/Modbus/RTU/Makefile
+++ b/protocols/Modbus/RTU/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Modbus bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/protocols/Modbus/include
 INCLUDE += -I$(PROJECT_BASE)/devices/Serial/include

--- a/protocols/UDP/Makefile-Bundle
+++ b/protocols/UDP/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for IoT UDP Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = UDPEndpointImpl BundleActivator
 

--- a/protocols/WebTunnel/Makefile
+++ b/protocols/WebTunnel/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io WebTunnel bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/protocols/XBee/Makefile-Bundle
+++ b/protocols/XBee/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io XBee bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/devices/Devices/include
 INCLUDE += -I$(PROJECT_BASE)/devices/Serial/include

--- a/samples/SensorLog/Makefile
+++ b/samples/SensorLog/Makefile
@@ -6,11 +6,21 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
 
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
+
+include $(POCO_BASE)/build/rules/dylib
+
 all:
+	$(shell mkdir -p ../bundles)
+	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -n$(OSNAME) -a$(OSARCH) -o../bundles SensorLog.bndlspec
 	$(BUNDLE_TOOL) -o../bundles SensorLog.bndlspec
+
+
 
 clean:

--- a/services/DeviceStatus/Makefile-Bundle
+++ b/services/DeviceStatus/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io DeviceStatus bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = \
 	DeviceStatusServiceImpl \

--- a/services/MobileConnection/Legato/Makefile
+++ b/services/MobileConnection/Legato/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Legato MobileConnectionService bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 INCLUDE += -I$(PROJECT_BASE)/services/MobileConnection/include
 

--- a/services/MobileConnection/Makefile-Bundle
+++ b/services/MobileConnection/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for IoT MobileConnection Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+        BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/services/NetworkEnvironment/Makefile-Bundle
+++ b/services/NetworkEnvironment/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for IoT NetworkEnvironment Bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = NetworkEnvironmentServiceImpl BundleActivator
 

--- a/services/WebEvent/Makefile-Bundle
+++ b/services/WebEvent/Makefile-Bundle
@@ -4,9 +4,13 @@
 # Makefile for macchina.io WebEvent bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects = BundleActivator
 

--- a/webui/Ace/Makefile
+++ b/webui/Ace/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles Ace.bndlspec

--- a/webui/AngularFileUpload/Makefile
+++ b/webui/AngularFileUpload/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles AngularFileUpload.bndlspec

--- a/webui/AngularJS/Makefile
+++ b/webui/AngularJS/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles AngularJS.bndlspec

--- a/webui/AngularUITree/Makefile
+++ b/webui/AngularUITree/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles AngularUITree.bndlspec

--- a/webui/BundleAdmin/Makefile
+++ b/webui/BundleAdmin/Makefile
@@ -4,10 +4,15 @@
 # Makefile for macchina.io bundle administration utility
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspc
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+	PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspcd
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+	PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspc
+endif
 
 objects =  \
 	BundleRequestHandler \

--- a/webui/ChartJS/Makefile
+++ b/webui/ChartJS/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles ChartJS.bndlspec

--- a/webui/Common/Makefile
+++ b/webui/Common/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles Common.bndlspec

--- a/webui/Console/Makefile
+++ b/webui/Console/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io web console bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects =  \
 	ConsoleRequestHandler \

--- a/webui/Devices/Makefile
+++ b/webui/Devices/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles Devices.bndlspec

--- a/webui/GNSSTracking/Makefile
+++ b/webui/GNSSTracking/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles GNSSTracking.bndlspec

--- a/webui/Launcher/Makefile
+++ b/webui/Launcher/Makefile
@@ -4,10 +4,15 @@
 # Makefile for macchina.io web application launcher bundle
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspc
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+	PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspcd
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+	PAGECOMPILER = $(POCO_BASE)/PageCompiler/$(POCO_HOST_BINDIR)/cpspc
+endif
 
 objects =  \
 	LoginPage \

--- a/webui/MQTT/Makefile
+++ b/webui/MQTT/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles MQTT.bndlspec

--- a/webui/MomentJS/Makefile
+++ b/webui/MomentJS/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles MomentJS.bndlspec

--- a/webui/OpenLayers/Makefile
+++ b/webui/OpenLayers/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles OpenLayers.bndlspec

--- a/webui/Playground/Makefile
+++ b/webui/Playground/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Playground app
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects =  \
 	SandboxRequestHandler \

--- a/webui/Settings/Makefile
+++ b/webui/Settings/Makefile
@@ -4,9 +4,13 @@
 # Makefile for macchina.io Settings app
 #
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 objects =  \
 	SettingsRequestHandler \

--- a/webui/SystemInformation/Makefile
+++ b/webui/SystemInformation/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles SystemInformation.bndlspec

--- a/webui/TinyColor/Makefile
+++ b/webui/TinyColor/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles TinyColor.bndlspec

--- a/webui/jQuery/Makefile
+++ b/webui/jQuery/Makefile
@@ -6,9 +6,13 @@
 
 .PHONY: clean all
 
-BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
-
 include $(POCO_BASE)/build/rules/global
+
+ifneq (,$(findstring debug,$(DEFAULT_TARGET)))
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundled
+else
+	BUNDLE_TOOL = $(POCO_BASE)/OSP/BundleCreator/$(POCO_HOST_BINDIR)/bundle
+endif
 
 all:
 	$(SET_LD_LIBRARY_PATH) $(BUNDLE_TOOL) -o../bundles jQuery.bndlspec


### PR DESCRIPTION
If build with DEFAULT_TAGRET=shared_debug, then build should be failed, because into make files using bundle tool and cpspc only, but into debug mode bundled and cpscd are needed