### PR TITLE
Fix GPIO Device Type

### DIFF
--- a/devices/Linux/Linux.bndlspec
+++ b/devices/Linux/Linux.bndlspec
@@ -2,7 +2,7 @@
 	<manifest>
     	<name>macchina.io Linux Devices</name>
 		<symbolicName>io.macchina.linux</symbolicName>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<vendor>Applied Informatics</vendor>
 		<copyright>(c) 2015-2018, Applied Informatics Software Engineering GmbH</copyright>
 		<activator>

--- a/devices/Linux/src/BundleActivator.cpp
+++ b/devices/Linux/src/BundleActivator.cpp
@@ -121,7 +121,7 @@ public:
 
 		Properties props;
 		props.set("io.macchina.device", LinuxGPIO::SYMBOLIC_NAME);
-		props.set("io.macchina.deviceType", "io.macchina.gpio");
+		props.set("io.macchina.deviceType", LinuxGPIO::TYPE);
 
 		ServiceRef::Ptr pServiceRef = _pContext->registry().registerService(oid, pGPIORemoteObject, props);
 		_serviceRefs.push_back(pServiceRef);

--- a/devices/Linux/src/BundleActivator.cpp
+++ b/devices/Linux/src/BundleActivator.cpp
@@ -168,9 +168,8 @@ public:
 					std::string baseKey = "linux.gpio.pins.";
 					baseKey += *it;
 
-					std::string device = _pPrefs->configuration()->getString(baseKey + ".device", "");
 					std::string direction = _pPrefs->configuration()->getString(baseKey + ".direction", "out");
-					gpioMap[device] = direction;
+					gpioMap[*it] = direction;
 				}
 
 				createGPIOs(gpioMap);

--- a/devices/Linux/src/LinuxGPIO.cpp
+++ b/devices/Linux/src/LinuxGPIO.cpp
@@ -26,7 +26,7 @@ namespace Linux {
 
 
 const std::string LinuxGPIO::NAME("Linux GPIO");
-const std::string LinuxGPIO::TYPE("io.macchina.io");
+const std::string LinuxGPIO::TYPE("io.macchina.gpio");
 const std::string LinuxGPIO::SYMBOLIC_NAME("io.macchina.linux.gpio");
 const std::string LinuxGPIO::LOGGER_NAME("IoT.LinuxGPIO");
 

--- a/server/macchina.properties
+++ b/server/macchina.properties
@@ -177,3 +177,11 @@ openSSL.client.verificationDepth = 9
 openSSL.client.loadDefaultCAFile = false
 openSSL.client.caConfig = ${application.configDir}rootcert.pem
 openSSL.client.invalidCertificateHandler.name = RejectCertificateHandler
+
+
+#
+# GPIO Configuration
+#
+#linux.gpio.enable = true
+#linux.gpio.pins.10.direction = out
+#linux.gpio.pins.11.direction = in

--- a/server/macchina.properties.install
+++ b/server/macchina.properties.install
@@ -24,7 +24,7 @@ auth.simple.admin.passwordHash = 21232f297a57a5a743894a0e4a801fc3
 #
 # Serial Ports
 #
-#serial.ports.1.device = /dev/tty.usbserial 
+#serial.ports.1.device = /dev/tty.usbserial
 #serial.ports.1.params = 8N1
 #serial.ports.1.speed = 57600
 
@@ -144,3 +144,11 @@ openSSL.client.verificationDepth = 9
 openSSL.client.loadDefaultCAFile = false
 openSSL.client.caConfig = ${application.configDir}rootcert.pem
 openSSL.client.invalidCertificateHandler.name = RejectCertificateHandler
+
+
+#
+# GPIO Configuration
+#
+#linux.gpio.enable = true
+#linux.gpio.pins.10.direction = out
+#linux.gpio.pins.11.direction = in


### PR DESCRIPTION
Hi!

This PR fixes the wrong name for GPIO on Linux bundle. Without this fix, GPIO Web UI won't work well.

Also, I updated the configuration to present GPIO on properties.

Regards. 