### PR TITLE
Update build config X-Debian-Stretch-RPi c++ std to 14

### DIFF
--- a/platform/build/config/X-Debian-Stretch-RPi
+++ b/platform/build/config/X-Debian-Stretch-RPi
@@ -43,7 +43,7 @@ SHAREDLIBLINKEXT = .so
 CFLAGS          = -std=c99 $(ARCHFLAGS)
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = -std=c++11 -Wall -Wno-sign-compare $(ARCHFLAGS)
+CXXFLAGS        = -std=c++14 -Wall -Wno-sign-compare $(ARCHFLAGS)
 CXXFLAGS32      =
 CXXFLAGS64      =
 LINKFLAGS       =


### PR DESCRIPTION
Since POCO requires c++14 the c++std version needs to be bumped up from c++11 to c++14.

Without this fix, the build fails due to [operator ""s on string literals](https://en.cppreference.com/w/cpp/string/basic_string/operator%22%22s):

```
src/LoggerWrapper.cpp:27:22: error: 'string_literals' is not a namespace-name
   27 | using namespace std::string_literals;
      |                      ^~~~~~~~~~~~~~~
src/LoggerWrapper.cpp: In member function 'virtual v8::Handle<v8::ObjectTemplate> Poco::JS::Core::LoggerWrapper::objectTemplate(v8::Isolate*)':
src/LoggerWrapper.cpp:69:86: error: unable to find string literal operator 'operator""s' with 'const char [12]', 'unsigned int' arguments
   69 |  v8::Persistent<v8::ObjectTemplate>& pooledLoggerTemplate(pPooledIso->objectTemplate("Core.Logger"s));
      |                                                                                      ^~~~~~~~~~~~~~
make[2]: *** [[redacted]/macchina.io/platform/build/rules/compile:61: [redacted]/macchina.io/platform/JS/Core/obj/Linux/armv7l/release_shared/LoggerWrapper.o] Error 1
```

By applying this fix, this config compiles as intended.