### PR TITLE
fix(bundle): fix path property

### DIFF
--- a/platform/OSP/JS/src/BundleWrapper.cpp
+++ b/platform/OSP/JS/src/BundleWrapper.cpp
@@ -39,7 +39,7 @@ v8::Handle<v8::ObjectTemplate> BundleWrapper::objectTemplate(v8::Isolate* pIsola
 	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "name"), name);
 	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "symbolicName"), symbolicName);
 	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "version"), version);
-	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "path"), name);
+	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "path"), path);
 	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "state"), state);
 	bundleTemplate->SetAccessor(v8::String::NewFromUtf8(pIsolate, "active"), active);
 	bundleTemplate->Set(v8::String::NewFromUtf8(pIsolate, "getResourceString"), v8::FunctionTemplate::New(pIsolate, getResourceString));


### PR DESCRIPTION
Günter,  it wrongly returned the `name` instead of `path`.
Also, I'm not sure if your idea for `path` was to result the bundle's root path?   because currently it returns the compiled bundle path (`/<path>/bundles/com.bundle.bndl`)